### PR TITLE
Bump textual to v8, textual-plotext to v1, rich to v14

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1143,7 +1143,6 @@ markers = {main = "extra == \"cli\""}
 
 [package.dependencies]
 linkify-it-py = {version = ">=1,<3", optional = true, markers = "extra == \"linkify\""}
-mdit-py-plugins = {version = ">=0.5.0", optional = true, markers = "extra == \"plugins\""}
 mdurl = ">=0.1,<1.0"
 
 [package.extras]
@@ -2520,42 +2519,44 @@ test = ["pytest", "tornado (>=4.5)", "typeguard"]
 
 [[package]]
 name = "textual"
-version = "3.7.1"
+version = "8.2.3"
 description = "Modern Text User Interface framework"
+optional = true
+python-versions = "<4.0,>=3.9"
+groups = ["main"]
+markers = "python_version < \"4.0\" and extra == \"cli\""
+files = [
+    {file = "textual-8.2.3-py3-none-any.whl", hash = "sha256:5008ac581bebf1f6fa0520404261844a231e5715fdbddd10ca73916a3af48ca2"},
+    {file = "textual-8.2.3.tar.gz", hash = "sha256:beea7b86b03b03558a2224f0cc35252e60ef8b0c4353b117b2f40972902d976a"},
+]
+
+[package.dependencies]
+markdown-it-py = {version = ">=2.1.0", extras = ["linkify"]}
+mdit-py-plugins = "*"
+platformdirs = ">=3.6.0,<5"
+pygments = ">=2.19.2,<3.0.0"
+rich = ">=14.2.0"
+typing-extensions = ">=4.4.0,<5.0.0"
+
+[package.extras]
+syntax = ["tree-sitter (>=0.25.0) ; python_version >= \"3.10\"", "tree-sitter-bash (>=0.23.0) ; python_version >= \"3.10\"", "tree-sitter-css (>=0.23.0) ; python_version >= \"3.10\"", "tree-sitter-go (>=0.23.0) ; python_version >= \"3.10\"", "tree-sitter-html (>=0.23.0) ; python_version >= \"3.10\"", "tree-sitter-java (>=0.23.0) ; python_version >= \"3.10\"", "tree-sitter-javascript (>=0.23.0) ; python_version >= \"3.10\"", "tree-sitter-json (>=0.24.0) ; python_version >= \"3.10\"", "tree-sitter-markdown (>=0.3.0) ; python_version >= \"3.10\"", "tree-sitter-python (>=0.23.0) ; python_version >= \"3.10\"", "tree-sitter-regex (>=0.24.0) ; python_version >= \"3.10\"", "tree-sitter-rust (>=0.23.0) ; python_version >= \"3.10\"", "tree-sitter-sql (>=0.3.11) ; python_version >= \"3.10\"", "tree-sitter-toml (>=0.6.0) ; python_version >= \"3.10\"", "tree-sitter-xml (>=0.7.0) ; python_version >= \"3.10\"", "tree-sitter-yaml (>=0.6.0) ; python_version >= \"3.10\""]
+
+[[package]]
+name = "textual-plotext"
+version = "1.0.1"
+description = "A Textual widget wrapper for the Plotext plotting library"
 optional = true
 python-versions = "<4.0.0,>=3.8.1"
 groups = ["main"]
 markers = "python_version < \"4.0\" and extra == \"cli\""
 files = [
-    {file = "textual-3.7.1-py3-none-any.whl", hash = "sha256:ab5d153f4f65e77017977fa150d0376409e0acf5f1d2e25e2e4ab9de6c0d61ff"},
-    {file = "textual-3.7.1.tar.gz", hash = "sha256:a76ba0c8a6c194ef24fd5c3681ebfddca55e7127c064a014128c84fbd7f5d271"},
-]
-
-[package.dependencies]
-markdown-it-py = {version = ">=2.1.0", extras = ["linkify", "plugins"]}
-platformdirs = ">=3.6.0,<5"
-rich = ">=13.3.3"
-typing-extensions = ">=4.4.0,<5.0.0"
-
-[package.extras]
-syntax = ["tree-sitter (>=0.23.0) ; python_version >= \"3.9\"", "tree-sitter-bash (>=0.23.0) ; python_version >= \"3.9\"", "tree-sitter-css (>=0.23.0) ; python_version >= \"3.9\"", "tree-sitter-go (>=0.23.0) ; python_version >= \"3.9\"", "tree-sitter-html (>=0.23.0) ; python_version >= \"3.9\"", "tree-sitter-java (>=0.23.0) ; python_version >= \"3.9\"", "tree-sitter-javascript (>=0.23.0) ; python_version >= \"3.9\"", "tree-sitter-json (>=0.24.0) ; python_version >= \"3.9\"", "tree-sitter-markdown (>=0.3.0) ; python_version >= \"3.9\"", "tree-sitter-python (>=0.23.0) ; python_version >= \"3.9\"", "tree-sitter-regex (>=0.24.0) ; python_version >= \"3.9\"", "tree-sitter-rust (>=0.23.0,<=0.23.2) ; python_version >= \"3.9\"", "tree-sitter-sql (>=0.3.0,<0.3.8) ; python_version >= \"3.9\"", "tree-sitter-toml (>=0.6.0) ; python_version >= \"3.9\"", "tree-sitter-xml (>=0.7.0) ; python_version >= \"3.9\"", "tree-sitter-yaml (>=0.6.0) ; python_version >= \"3.9\""]
-
-[[package]]
-name = "textual-plotext"
-version = "0.2.1"
-description = "A Textual widget wrapper for the Plotext plotting library"
-optional = true
-python-versions = ">=3.7.2,<4.0"
-groups = ["main"]
-markers = "python_version < \"4.0\" and extra == \"cli\""
-files = [
-    {file = "textual_plotext-0.2.1-py3-none-any.whl", hash = "sha256:a1055cf50fac9af11f56b5ff73442570eb5fd051e513b20aeb8b15a6a2abfcff"},
-    {file = "textual_plotext-0.2.1.tar.gz", hash = "sha256:bc6f2d75d8e20dda6321f8254dc3decda8f41f60e6e70a3ddd83b652b890c081"},
+    {file = "textual_plotext-1.0.1-py3-none-any.whl", hash = "sha256:6b6bfd00b29f121ddf216eaaf9bdac9d688ed72f40028484d279a10cbbb169ed"},
+    {file = "textual_plotext-1.0.1.tar.gz", hash = "sha256:836f53a3316756609e194129a35c2875638e7958c261f541e0a794f7c98011be"},
 ]
 
 [package.dependencies]
 plotext = ">=5.2.8,<6.0.0"
-textual = ">=0.40.0"
+textual = ">=0.86.2"
 
 [[package]]
 name = "tomlkit"
@@ -2887,4 +2888,4 @@ cli = ["rich", "textual", "textual-plotext", "typer"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "2593f54b069548d24a84099ed8bc4cabb87a507bdb818faca5399df124caec1a"
+content-hash = "4ad793ca35c2f61eda9e35957fe5459448b5967e5c4b664498e96179fe29ef5b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ packages = [{ include = "fumis", from = "src" }]
 dependencies = ['aiohttp (>=3.0.0)', 'awesomeversion (>=22.0.0)', 'mashumaro (>=3.13,<4.0.0)', 'orjson (>=3.9.8)', 'yarl (>=1.6.0)']
 
 [project.optional-dependencies]
-cli = ["rich>=13.0.0", "textual>=3.0.0,<4.0.0; python_version<'4.0'", "textual-plotext>=0.2.0,<1.0.0; python_version<'4.0'", "typer>=0.15.1"]
+cli = ["rich>=14.0.0", "textual>=8.0.0,<9.0.0; python_version<'4.0'", "textual-plotext>=1.0.0,<2.0.0; python_version<'4.0'", "typer>=0.15.1"]
 
 [project.scripts]
 fumis = "fumis._cli:main"


### PR DESCRIPTION
## Summary

- Bump `textual` from `>=3.0.0,<4.0.0` to `>=8.0.0,<9.0.0`
- Bump `textual-plotext` from `>=0.2.0,<1.0.0` to `>=1.0.0,<2.0.0`
- Bump `rich` from `>=13.0.0` to `>=14.0.0`

`textual-plotext` 0.x is incompatible with textual 8 (`DEFAULT_COLORS` was removed from `textual.app`). Both packages need to be bumped together.

Supersedes #525 (Renovate only bumped textual without textual-plotext, which breaks the TUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)