### PR TITLE
Fix on property: use status instead of transient command field

### DIFF
--- a/src/fumis/cli/__init__.py
+++ b/src/fumis/cli/__init__.py
@@ -181,13 +181,6 @@ def _status_display(c: Controller) -> str:
     status = c.stove_status
     icon = STATUS_ICONS.get(status, "\u2753")
     label = status.name.replace("_", " ").title()
-
-    # Show a hint when state and status disagree
-    if status == StoveStatus.OFF and c.on:
-        return f"\U0001f9e8 {label} [dim](starting\u2026)[/dim]"
-    if status != StoveStatus.OFF and not c.on:
-        return f"{icon}  {label} [dim](shutting down\u2026)[/dim]"
-
     return f"{icon}  {label}"
 
 

--- a/src/fumis/cli/tui.py
+++ b/src/fumis/cli/tui.py
@@ -48,10 +48,6 @@ class StatusWidget(Static):
         icon = STATUS_ICONS.get(status, "\u2753")
 
         status_label = status.name.replace("_", " ").title()
-        if status == StoveStatus.OFF and c.on:
-            status_label += " (starting\u2026)"
-        elif status != StoveStatus.OFF and not c.on:
-            status_label += " (shutting down\u2026)"
 
         main_temp = c.main_temperature
         temp_str = ""

--- a/src/fumis/models.py
+++ b/src/fumis/models.py
@@ -433,8 +433,17 @@ class Controller(_BaseModel):
 
     @property
     def on(self) -> bool:
-        """Return whether the stove is commanded on."""
-        return self.command == 2
+        """Return whether the stove is operationally active.
+
+        Based on status, not command. The command field is transient
+        and resets after being acknowledged by the controller.
+        """
+        return self.stove_status not in (
+            StoveStatus.OFF,
+            StoveStatus.COLD_START_OFF,
+            StoveStatus.WOOD_BURNING_OFF,
+            StoveStatus.UNKNOWN,
+        )
 
     # -- Temperatures --
 

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -1227,15 +1227,15 @@
     ID: AABBCCDDEEFF • WiRCU 2.5.0 • Controller 2.6.0 • API 1.3
   
   ╭────────────────────── Status ──────────────────────╮
-  │   🏠 Status          ❄  Cooling (shutting down…)   │
-  │   🌡️  Temperature    20.7° → 25.0°                 │
-  │   🔥 Combustion      206.0°                        │
-  │   ⚡ Power           4.6 kW (level 5)              │
-  │   ⛽ Fuel            █████████░ 95%                │
-  │   🚪 Door            Closed                        │
-  │   ⭘  Eco mode        Off                           │
-  │   ❄️  Antifreeze     On (5.0°)                     │
-  │   🪵  Hybrid         Yes                           │
+  │   🏠 Status                ❄  Cooling              │
+  │   🌡️  Temperature          20.7° → 25.0°           │
+  │   🔥 Combustion            206.0°                  │
+  │   ⚡ Power                 4.6 kW (level 5)        │
+  │   ⛽ Fuel                  █████████░ 95%          │
+  │   🚪 Door                  Closed                  │
+  │   ⭘  Eco mode              Off                     │
+  │   ❄️  Antifreeze           On (5.0°)               │
+  │   🪵  Hybrid               Yes                     │
   ╰────────────────────────────────────────────────────╯
    ╭───────── Network ──────────╮  ╭────── Statistics ──────╮ 
    │  📡 IP      192.168.1.2    │  │  🔄 Starts   2         │ 
@@ -1253,12 +1253,12 @@
     ID: AABBCCDDEEFF • WiRCU 2.0.0 • Controller 1.7.0 • API 1.0
   
   ╭────────────────────── Status ──────────────────────╮
-  │   🏠 Status               🧨 Off (starting…)       │
-  │   🌡️  Temperature         19.9° → 21.8°            │
-  │   💨 Exhaust              23°                      │
-  │   ⚡ Power                0.0 kW (level 2)         │
-  │   ⛽ Fuel                 ░░░░░░░░░░ 0%            │
-  │   ⭘  Eco mode             Off                      │
+  │   🏠 Status                ⭘  Off                  │
+  │   🌡️  Temperature          19.9° → 21.8°           │
+  │   💨 Exhaust               23°                     │
+  │   ⚡ Power                 0.0 kW (level 2)        │
+  │   ⛽ Fuel                  ░░░░░░░░░░ 0%           │
+  │   ⭘  Eco mode              Off                     │
   ╰────────────────────────────────────────────────────╯
    ╭───────── Network ─────────╮  ╭───── Statistics ─────╮ 
    │  📡 IP    192.168.1.2     │  │  🔄 Starts   392     │ 

--- a/tests/test_fumis.py
+++ b/tests/test_fumis.py
@@ -617,9 +617,18 @@ def test_unknown_status_code() -> None:
     assert info.controller.stove_status == StoveStatus.UNKNOWN
 
 
-def test_unknown_command_code() -> None:
-    """Test unknown command code treats stove as off."""
-    info = Info.from_dict({"controller": {"command": 99}})
+def test_on_based_on_status() -> None:
+    """Test on property is based on status, not command."""
+    # Status OFF = not on, regardless of command
+    info = Info.from_dict({"controller": {"status": 0, "command": 2}})
+    assert info.controller.on is False
+
+    # Status COMBUSTION = on, even with command=1 (normal after ack)
+    info = Info.from_dict({"controller": {"status": 30, "command": 1}})
+    assert info.controller.on is True
+
+    # Unknown status = not on
+    info = Info.from_dict({"controller": {"status": 999}})
     assert info.controller.on is False
 
 


### PR DESCRIPTION
## Summary

- The `command` field resets to 1 (OFF) after being acknowledged by the controller, so a running stove in COMBUSTION has `command=1`. This caused `controller.on` to return `False` and the CLI to display "shutting down" for a stove that was actively burning at 400+ degrees.
- The `on` property now checks whether `stove_status` is operationally active instead of relying on the `command` field
- Removes the unreliable "starting/shutting down" hints from the CLI and TUI that were based on command/status disagreement

Confirmed by live testing: stove in COMBUSTION with `command=1` now correctly shows `on=True` and status "Combustion" without the spurious "shutting down" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)