### PR TITLE
Add simplified StoveState enum derived from raw status codes

### DIFF
--- a/src/fumis/__init__.py
+++ b/src/fumis/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .const import StoveModelInfo, StoveStatus
+from .const import StoveModelInfo, StoveState, StoveStatus
 from .exceptions import (
     FumisAuthenticationError,
     FumisConnectionError,
@@ -50,6 +50,7 @@ __all__ = [
     "Power",
     "Statistic",
     "StoveModelInfo",
+    "StoveState",
     "StoveStatus",
     "Temperature",
     "TimerProgram",

--- a/src/fumis/const.py
+++ b/src/fumis/const.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 from typing import Any
 
 
@@ -59,6 +59,55 @@ class StoveStatus(IntEnum):
     def _missing_(cls, value: object) -> Any:  # noqa: ARG003
         """Return UNKNOWN for unmapped status codes."""
         return cls.UNKNOWN
+
+
+class StoveState(StrEnum):
+    """Simplified stove state derived from the raw status code.
+
+    Mirrors the state machine in the Fumis mobile app. Maps the 14 raw
+    StoveStatus codes into consumer-friendly states.
+    """
+
+    OFF = "off"
+    """Stove is off (idle, post-cold-start, or post-wood-burning)."""
+
+    HEATING_UP = "heating_up"
+    """Stove is warming up before ignition."""
+
+    IGNITION = "ignition"
+    """Igniter is active or fire is catching."""
+
+    BURNING = "burning"
+    """Stove is actively burning (pellet or wood combustion)."""
+
+    ECO = "eco"
+    """Eco mode, maintaining temperature at reduced output."""
+
+    COOLING = "cooling"
+    """Stove is cooling down after being turned off."""
+
+    UNKNOWN = "unknown"
+    """Unknown or unmapped status."""
+
+
+#: Maps each raw StoveStatus to a simplified StoveState.
+_STATUS_TO_STATE: dict[StoveStatus, StoveState] = {
+    StoveStatus.OFF: StoveState.OFF,
+    StoveStatus.COLD_START_OFF: StoveState.OFF,
+    StoveStatus.WOOD_BURNING_OFF: StoveState.OFF,
+    StoveStatus.PRE_HEATING: StoveState.HEATING_UP,
+    StoveStatus.IGNITION: StoveState.IGNITION,
+    StoveStatus.PRE_COMBUSTION: StoveState.IGNITION,
+    StoveStatus.COMBUSTION: StoveState.BURNING,
+    StoveStatus.ECO: StoveState.ECO,
+    StoveStatus.COOLING: StoveState.COOLING,
+    StoveStatus.HYBRID_INIT: StoveState.HEATING_UP,
+    StoveStatus.HYBRID_START: StoveState.IGNITION,
+    StoveStatus.WOOD_START: StoveState.IGNITION,
+    StoveStatus.COLD_START: StoveState.HEATING_UP,
+    StoveStatus.WOOD_COMBUSTION: StoveState.BURNING,
+    StoveStatus.UNKNOWN: StoveState.UNKNOWN,
+}
 
 
 @dataclass(frozen=True)

--- a/src/fumis/const.py
+++ b/src/fumis/const.py
@@ -89,8 +89,12 @@ class StoveState(StrEnum):
     UNKNOWN = "unknown"
     """Unknown or unmapped status."""
 
+    @classmethod
+    def from_status(cls, status: StoveStatus) -> StoveState:
+        """Convert a raw StoveStatus to a simplified StoveState."""
+        return _STATUS_TO_STATE.get(status, cls.UNKNOWN)
 
-#: Maps each raw StoveStatus to a simplified StoveState.
+
 _STATUS_TO_STATE: dict[StoveStatus, StoveState] = {
     StoveStatus.OFF: StoveState.OFF,
     StoveStatus.COLD_START_OFF: StoveState.OFF,

--- a/src/fumis/models.py
+++ b/src/fumis/models.py
@@ -11,7 +11,13 @@ from mashumaro.config import BaseConfig
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 from mashumaro.types import SerializationStrategy
 
-from .const import STOVE_MODELS, StoveModelInfo, StoveStatus
+from .const import (
+    _STATUS_TO_STATE,
+    STOVE_MODELS,
+    StoveModelInfo,
+    StoveState,
+    StoveStatus,
+)
 
 
 class _AwesomeVersionStrategy(SerializationStrategy):
@@ -444,6 +450,15 @@ class Controller(_BaseModel):
             StoveStatus.WOOD_BURNING_OFF,
             StoveStatus.UNKNOWN,
         )
+
+    @property
+    def state(self) -> StoveState:
+        """Return the simplified stove state.
+
+        Maps the 14 raw status codes into consumer-friendly states
+        (off, heating_up, ignition, burning, eco, cooling, unknown).
+        """
+        return _STATUS_TO_STATE.get(self.stove_status, StoveState.UNKNOWN)
 
     # -- Temperatures --
 

--- a/src/fumis/models.py
+++ b/src/fumis/models.py
@@ -11,13 +11,7 @@ from mashumaro.config import BaseConfig
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 from mashumaro.types import SerializationStrategy
 
-from .const import (
-    _STATUS_TO_STATE,
-    STOVE_MODELS,
-    StoveModelInfo,
-    StoveState,
-    StoveStatus,
-)
+from .const import STOVE_MODELS, StoveModelInfo, StoveState, StoveStatus
 
 
 class _AwesomeVersionStrategy(SerializationStrategy):
@@ -458,7 +452,7 @@ class Controller(_BaseModel):
         Maps the 14 raw status codes into consumer-friendly states
         (off, heating_up, ignition, burning, eco, cooling, unknown).
         """
-        return _STATUS_TO_STATE.get(self.stove_status, StoveState.UNKNOWN)
+        return StoveState.from_status(self.stove_status)
 
     # -- Temperatures --
 

--- a/src/fumis/models.py
+++ b/src/fumis/models.py
@@ -368,7 +368,7 @@ class WeekSchedule:
 
 
 @dataclass(frozen=True)
-# pylint: disable-next=too-many-instance-attributes
+# pylint: disable-next=too-many-instance-attributes,too-many-public-methods
 class Controller(_BaseModel):
     """Fumis stove controller state."""
 

--- a/tests/test_fumis.py
+++ b/tests/test_fumis.py
@@ -633,43 +633,34 @@ def test_on_based_on_status() -> None:
     assert info.controller.on is False
 
 
-def test_stove_state() -> None:
-    """Test simplified state derived from raw status."""
-    # OFF statuses map to OFF state
-    info = Info.from_dict({"controller": {"status": 0}})
-    assert info.controller.state == StoveState.OFF
+@pytest.mark.parametrize(
+    ("status_code", "expected_state"),
+    [
+        (0, StoveState.OFF),  # OFF
+        (1, StoveState.OFF),  # COLD_START_OFF
+        (2, StoveState.OFF),  # WOOD_BURNING_OFF
+        (10, StoveState.HEATING_UP),  # PRE_HEATING
+        (20, StoveState.IGNITION),  # IGNITION
+        (21, StoveState.IGNITION),  # PRE_COMBUSTION
+        (30, StoveState.BURNING),  # COMBUSTION
+        (40, StoveState.ECO),  # ECO
+        (50, StoveState.COOLING),  # COOLING
+        (60, StoveState.HEATING_UP),  # HYBRID_INIT
+        (80, StoveState.IGNITION),  # HYBRID_START
+        (90, StoveState.IGNITION),  # WOOD_START
+        (100, StoveState.HEATING_UP),  # COLD_START
+        (110, StoveState.BURNING),  # WOOD_COMBUSTION
+        (999, StoveState.UNKNOWN),  # unmapped
+    ],
+)
+def test_stove_state(status_code: int, expected_state: StoveState) -> None:
+    """Test simplified state derived from raw status for all mappings."""
+    info = Info.from_dict({"controller": {"status": status_code}})
+    assert info.controller.state == expected_state
 
-    # PRE_HEATING maps to HEATING_UP
-    info = Info.from_dict({"controller": {"status": 10}})
-    assert info.controller.state == StoveState.HEATING_UP
 
-    # IGNITION and PRE_COMBUSTION map to IGNITION
-    info = Info.from_dict({"controller": {"status": 20}})
-    assert info.controller.state == StoveState.IGNITION
-    info = Info.from_dict({"controller": {"status": 21}})
-    assert info.controller.state == StoveState.IGNITION
-
-    # COMBUSTION maps to BURNING
-    info = Info.from_dict({"controller": {"status": 30}})
-    assert info.controller.state == StoveState.BURNING
-
-    # ECO maps to ECO
-    info = Info.from_dict({"controller": {"status": 40}})
-    assert info.controller.state == StoveState.ECO
-
-    # COOLING maps to COOLING
-    info = Info.from_dict({"controller": {"status": 50}})
-    assert info.controller.state == StoveState.COOLING
-
-    # WOOD_COMBUSTION maps to BURNING
-    info = Info.from_dict({"controller": {"status": 110}})
-    assert info.controller.state == StoveState.BURNING
-
-    # Unknown maps to UNKNOWN
-    info = Info.from_dict({"controller": {"status": 999}})
-    assert info.controller.state == StoveState.UNKNOWN
-
-    # StrEnum serializes cleanly
+def test_stove_state_is_str_enum() -> None:
+    """Test StoveState serializes cleanly as a string."""
     assert str(StoveState.BURNING) == "burning"
 
 

--- a/tests/test_fumis.py
+++ b/tests/test_fumis.py
@@ -18,6 +18,7 @@ from fumis import (
     FumisResponseError,
     FumisStoveOfflineError,
     Info,
+    StoveState,
     StoveStatus,
 )
 
@@ -630,6 +631,46 @@ def test_on_based_on_status() -> None:
     # Unknown status = not on
     info = Info.from_dict({"controller": {"status": 999}})
     assert info.controller.on is False
+
+
+def test_stove_state() -> None:
+    """Test simplified state derived from raw status."""
+    # OFF statuses map to OFF state
+    info = Info.from_dict({"controller": {"status": 0}})
+    assert info.controller.state == StoveState.OFF
+
+    # PRE_HEATING maps to HEATING_UP
+    info = Info.from_dict({"controller": {"status": 10}})
+    assert info.controller.state == StoveState.HEATING_UP
+
+    # IGNITION and PRE_COMBUSTION map to IGNITION
+    info = Info.from_dict({"controller": {"status": 20}})
+    assert info.controller.state == StoveState.IGNITION
+    info = Info.from_dict({"controller": {"status": 21}})
+    assert info.controller.state == StoveState.IGNITION
+
+    # COMBUSTION maps to BURNING
+    info = Info.from_dict({"controller": {"status": 30}})
+    assert info.controller.state == StoveState.BURNING
+
+    # ECO maps to ECO
+    info = Info.from_dict({"controller": {"status": 40}})
+    assert info.controller.state == StoveState.ECO
+
+    # COOLING maps to COOLING
+    info = Info.from_dict({"controller": {"status": 50}})
+    assert info.controller.state == StoveState.COOLING
+
+    # WOOD_COMBUSTION maps to BURNING
+    info = Info.from_dict({"controller": {"status": 110}})
+    assert info.controller.state == StoveState.BURNING
+
+    # Unknown maps to UNKNOWN
+    info = Info.from_dict({"controller": {"status": 999}})
+    assert info.controller.state == StoveState.UNKNOWN
+
+    # StrEnum serializes cleanly
+    assert str(StoveState.BURNING) == "burning"
 
 
 def test_eco_mode_enabled() -> None:


### PR DESCRIPTION
## Summary

- Adds a `StoveState` StrEnum that maps the 14 raw `StoveStatus` codes into 7 consumer-friendly states: `off`, `heating_up`, `ignition`, `burning`, `eco`, `cooling`, `unknown`
- Mirrors the state machine found in the Fumis mobile app (`STOVE_STATE_OFF`, `STOVE_STATE_HEATUP`, `STOVE_STATE_IGNITION`, `STOVE_STATE_BURNING`, `STOVE_STATE_BURNWAIT`, `STOVE_STATE_COOLDOWN`)
- Accessible via `controller.state` alongside the existing `controller.stove_status` for consumers who need the raw detail
- Hybrid status codes (HYBRID_INIT, HYBRID_START, WOOD_START, COLD_START, WOOD_COMBUSTION) are mapped to their logical equivalents (heating_up, ignition, burning)

```python
from fumis import Fumis, StoveState

info = await fumis.update_info()
info.controller.state                        # StoveState.BURNING
info.controller.state == StoveState.BURNING  # True
f"Stove is {info.controller.state}"          # "Stove is burning"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)