### PR TITLE
Add StoveError and StoveAlert StrEnums matching device display

### DIFF
--- a/src/fumis/__init__.py
+++ b/src/fumis/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .const import StoveModelInfo, StoveState, StoveStatus
+from .const import StoveAlert, StoveError, StoveModelInfo, StoveState, StoveStatus
 from .exceptions import (
     FumisAuthenticationError,
     FumisConnectionError,
@@ -53,6 +53,8 @@ __all__ = [
     "FumisTimerProgram",
     "FumisUnit",
     "FumisWeekSchedule",
+    "StoveAlert",
+    "StoveError",
     "StoveModelInfo",
     "StoveState",
     "StoveStatus",

--- a/src/fumis/cli/__init__.py
+++ b/src/fumis/cli/__init__.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from fumis.const import StoveStatus
+from fumis.const import StoveError, StoveStatus
 from fumis.exceptions import (
     FumisAuthenticationError,
     FumisConnectionError,
@@ -215,17 +215,15 @@ def _render_info(  # noqa: PLR0912, PLR0915  # pylint: disable=too-many-branches
 
     status_table.add_row("\U0001f3e0 Status", _status_display(c))
 
-    if c.error:
-        error_desc = ERROR_DESCRIPTIONS.get(c.error, "Unknown")
+    if error := c.stove_error:
         status_table.add_row(
             "\u274c Error",
-            f"[red bold]E{c.error}[/red bold] [dim]{error_desc}[/dim]",
+            f"[red bold]{error}[/red bold] [dim]{error.description}[/dim]",
         )
-    if c.alert:
-        alert_desc = ALERT_DESCRIPTIONS.get(c.alert, "Unknown")
+    if alert := c.stove_alert:
         status_table.add_row(
             "\u26a0\ufe0f  Alert",
-            f"[yellow bold]A{c.alert:03d}[/yellow bold] [dim]{alert_desc}[/dim]",
+            f"[yellow bold]{alert}[/yellow bold] [dim]{alert.description}[/dim]",
         )
 
     main_temp = c.main_temperature
@@ -511,46 +509,6 @@ async def sync_clock_command(
     console.print("\U0001f552 [green bold]Clock synced.[/green bold]")
 
 
-ERROR_DESCRIPTIONS: dict[int, str] = {
-    0: "No error",
-    101: "Ignition failed / water overtemperature / backfire protection",
-    102: "Chimney/burning pot dirty or manually stopped",
-    105: "Sensor T02 malfunction",
-    106: "Sensor T03/T05 malfunction",
-    107: "Sensor T04 malfunction",
-    108: "Security switch I01 tripped (STB)",
-    109: "Pressure sensor switched OFF",
-    110: "Sensor T01/T02 malfunction",
-    111: "Sensor T01/T03 malfunction",
-    113: "Flue gas overtemperature",
-    114: "Fuel ignition timeout / tank empty",
-    115: "General error",
-    239: "MFDoor Alarm",
-    240: "Fire Error",
-    241: "Chimney Alarm",
-    243: "Grate Error",
-    244: "NTC2 Alarm",
-    245: "NTC3 Alarm",
-    247: "Door Alarm",
-    248: "Pressure Alarm",
-    249: "NTC1 Alarm",
-    250: "TC1 Alarm",
-    252: "Gas Alarm",
-    253: "No Pellet Alarm",
-}
-
-ALERT_DESCRIPTIONS: dict[int, str] = {
-    0: "No alert",
-    1: "Low fuel level",
-    2: "Service due",
-    3: "Flue gas temperature warning",
-    4: "Low battery",
-    5: "Speed sensor failure",
-    6: "Door open",
-    7: "Airflow sensor malfunction (limited mode)",
-}
-
-
 def _format_error_date(date_val: int, time_val: int) -> str:
     """Format an error history date/time entry."""
     parts: list[str] = []
@@ -572,21 +530,19 @@ async def errors_command(
     c = info.controller
 
     # Current error
-    error_desc = ERROR_DESCRIPTIONS.get(c.error, "Unknown")
-    if c.error == 0:
-        console.print("\u2705 [green bold]No active error[/green bold]")
+    if error := c.stove_error:
+        console.print(f"\u274c [red bold]Error {error}:[/red bold] {error.description}")
     else:
-        console.print(f"\u274c [red bold]Error E{c.error}:[/red bold] {error_desc}")
+        console.print("\u2705 [green bold]No active error[/green bold]")
 
     # Current alert
-    alert_desc = ALERT_DESCRIPTIONS.get(c.alert, "Unknown")
-    if c.alert == 0:
-        console.print("\u2705 [green bold]No active alert[/green bold]")
-    else:
+    if alert := c.stove_alert:
         console.print(
-            f"\u26a0\ufe0f  [yellow bold]Alert A{c.alert:03d}:[/yellow bold]"
-            f" {alert_desc}"
+            f"\u26a0\ufe0f  [yellow bold]Alert {alert}:[/yellow bold]"
+            f" {alert.description}"
         )
+    else:
+        console.print("\u2705 [green bold]No active alert[/green bold]")
 
     # Error history from diagnostic variables
     # var[36..95] in groups of 4: [sequence, error_code, date(YYYYMMDD), time]
@@ -612,8 +568,14 @@ async def errors_command(
     table.add_column("Description")
     table.add_column("Date")
     for i, (code, date_val, time_val) in enumerate(history, 1):
-        desc = ERROR_DESCRIPTIONS.get(code, f"Unknown ({code})")
-        table.add_row(str(i), f"E{code}", desc, _format_error_date(date_val, time_val))
+        err = StoveError.from_code(code)
+        if err == StoveError.UNKNOWN:
+            label = f"E{code}"
+            desc = f"Unknown ({code})"
+        else:
+            label = str(err)
+            desc = err.description
+        table.add_row(str(i), label, desc, _format_error_date(date_val, time_val))
     console.print(table)
 
 

--- a/src/fumis/cli/__init__.py
+++ b/src/fumis/cli/__init__.py
@@ -569,7 +569,7 @@ async def errors_command(
     table.add_column("Date")
     for i, (code, date_val, time_val) in enumerate(history, 1):
         err = StoveError.from_code(code)
-        if err == StoveError.UNKNOWN:
+        if err is None or err == StoveError.UNKNOWN:
             label = f"E{code}"
             desc = f"Unknown ({code})"
         else:

--- a/src/fumis/cli/__init__.py
+++ b/src/fumis/cli/__init__.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from fumis.const import StoveError, StoveStatus
+from fumis.const import StoveAlert, StoveError, StoveStatus
 from fumis.exceptions import (
     FumisAuthenticationError,
     FumisConnectionError,
@@ -216,14 +216,16 @@ def _render_info(  # noqa: PLR0912, PLR0915  # pylint: disable=too-many-branches
     status_table.add_row("\U0001f3e0 Status", _status_display(c))
 
     if error := c.stove_error:
+        error_label = f"E{c.error}" if error == StoveError.UNKNOWN else str(error)
         status_table.add_row(
             "\u274c Error",
-            f"[red bold]{error}[/red bold] [dim]{error.description}[/dim]",
+            f"[red bold]{error_label}[/red bold] [dim]{error.description}[/dim]",
         )
     if alert := c.stove_alert:
+        alert_label = f"A{c.alert:03d}" if alert == StoveAlert.UNKNOWN else str(alert)
         status_table.add_row(
             "\u26a0\ufe0f  Alert",
-            f"[yellow bold]{alert}[/yellow bold] [dim]{alert.description}[/dim]",
+            f"[yellow bold]{alert_label}[/yellow bold] [dim]{alert.description}[/dim]",
         )
 
     main_temp = c.main_temperature
@@ -531,14 +533,16 @@ async def errors_command(
 
     # Current error
     if error := c.stove_error:
-        console.print(f"\u274c [red bold]Error {error}:[/red bold] {error.description}")
+        label = f"E{c.error}" if error == StoveError.UNKNOWN else str(error)
+        console.print(f"\u274c [red bold]Error {label}:[/red bold] {error.description}")
     else:
         console.print("\u2705 [green bold]No active error[/green bold]")
 
     # Current alert
     if alert := c.stove_alert:
+        label = f"A{c.alert:03d}" if alert == StoveAlert.UNKNOWN else str(alert)
         console.print(
-            f"\u26a0\ufe0f  [yellow bold]Alert {alert}:[/yellow bold]"
+            f"\u26a0\ufe0f  [yellow bold]Alert {label}:[/yellow bold]"
             f" {alert.description}"
         )
     else:

--- a/src/fumis/cli/__init__.py
+++ b/src/fumis/cli/__init__.py
@@ -216,7 +216,7 @@ def _render_info(  # noqa: PLR0912, PLR0915  # pylint: disable=too-many-branches
     status_table.add_row("\U0001f3e0 Status", _status_display(c))
 
     if error := c.stove_error:
-        error_label = f"E{c.error}" if error == StoveError.UNKNOWN else str(error)
+        error_label = f"E{c.error:03d}" if error == StoveError.UNKNOWN else str(error)
         status_table.add_row(
             "\u274c Error",
             f"[red bold]{error_label}[/red bold] [dim]{error.description}[/dim]",
@@ -533,7 +533,7 @@ async def errors_command(
 
     # Current error
     if error := c.stove_error:
-        label = f"E{c.error}" if error == StoveError.UNKNOWN else str(error)
+        label = f"E{c.error:03d}" if error == StoveError.UNKNOWN else str(error)
         console.print(f"\u274c [red bold]Error {label}:[/red bold] {error.description}")
     else:
         console.print("\u2705 [green bold]No active error[/green bold]")
@@ -574,7 +574,7 @@ async def errors_command(
     for i, (code, date_val, time_val) in enumerate(history, 1):
         err = StoveError.from_code(code)
         if err is None or err == StoveError.UNKNOWN:
-            label = f"E{code}"
+            label = f"E{code:03d}"
             desc = f"Unknown ({code})"
         else:
             label = str(err)

--- a/src/fumis/cli/tui.py
+++ b/src/fumis/cli/tui.py
@@ -74,7 +74,7 @@ class StatusWidget(Static):
 
         error_str = ""
         if error := c.stove_error:
-            label = f"E{c.error}" if error == StoveError.UNKNOWN else str(error)
+            label = f"E{c.error:03d}" if error == StoveError.UNKNOWN else str(error)
             error_str = f"\u274c {label}: {error.description}"
         if alert := c.stove_alert:
             label = f"A{c.alert:03d}" if alert == StoveAlert.UNKNOWN else str(alert)

--- a/src/fumis/cli/tui.py
+++ b/src/fumis/cli/tui.py
@@ -15,7 +15,6 @@ from textual.screen import ModalScreen
 from textual.widgets import Footer, Header, Label, Static
 from textual_plotext import PlotextPlot
 
-from fumis.cli import ALERT_DESCRIPTIONS, ERROR_DESCRIPTIONS
 from fumis.const import StoveStatus
 from fumis.fumis import Fumis
 
@@ -74,12 +73,10 @@ class StatusWidget(Static):
             eco_str = "\U0001f331 On" if eco.enabled else "Off"
 
         error_str = ""
-        if c.error:
-            desc = ERROR_DESCRIPTIONS.get(c.error, "Unknown")
-            error_str = f"\u274c E{c.error}: {desc}"
-        if c.alert:
-            desc = ALERT_DESCRIPTIONS.get(c.alert, "Unknown")
-            error_str += f"  \u26a0\ufe0f  A{c.alert:03d}: {desc}"
+        if error := c.stove_error:
+            error_str = f"\u274c {error}: {error.description}"
+        if alert := c.stove_alert:
+            error_str += f"  \u26a0\ufe0f  {alert}: {alert.description}"
 
         lines = [
             f"  {icon}  [bold]{status_label}[/bold]",

--- a/src/fumis/cli/tui.py
+++ b/src/fumis/cli/tui.py
@@ -15,7 +15,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Footer, Header, Label, Static
 from textual_plotext import PlotextPlot
 
-from fumis.const import StoveStatus
+from fumis.const import StoveAlert, StoveError, StoveStatus
 from fumis.fumis import Fumis
 
 if TYPE_CHECKING:
@@ -74,9 +74,11 @@ class StatusWidget(Static):
 
         error_str = ""
         if error := c.stove_error:
-            error_str = f"\u274c {error}: {error.description}"
+            label = f"E{c.error}" if error == StoveError.UNKNOWN else str(error)
+            error_str = f"\u274c {label}: {error.description}"
         if alert := c.stove_alert:
-            error_str += f"  \u26a0\ufe0f  {alert}: {alert.description}"
+            label = f"A{c.alert:03d}" if alert == StoveAlert.UNKNOWN else str(alert)
+            error_str += f"  \u26a0\ufe0f  {label}: {alert.description}"
 
         lines = [
             f"  {icon}  [bold]{status_label}[/bold]",

--- a/src/fumis/const.py
+++ b/src/fumis/const.py
@@ -268,7 +268,9 @@ class StoveAlert(StrEnum):
 
 
 _ERROR_DESCRIPTIONS: dict[StoveError, str] = {
-    StoveError.IGNITION_FAILED: "Ignition failed / water overtemperature / backfire protection",
+    StoveError.IGNITION_FAILED: (
+        "Ignition failed / water overtemperature / backfire protection"
+    ),
     StoveError.CHIMNEY_DIRTY: "Chimney/burning pot dirty or manually stopped",
     StoveError.SENSOR_T02: "Sensor T02 malfunction",
     StoveError.SENSOR_T03_T05: "Sensor T03/T05 malfunction",

--- a/src/fumis/const.py
+++ b/src/fumis/const.py
@@ -114,6 +114,197 @@ _STATUS_TO_STATE: dict[StoveStatus, StoveState] = {
 }
 
 
+class StoveError(StrEnum):
+    """Stove error code (from controller.error).
+
+    Values match the display format on the device (e.g., E102).
+    Use `StoveError.from_code()` to convert the raw integer from the API.
+    """
+
+    IGNITION_FAILED = "E101"
+    """Ignition failed, water overtemperature, or backfire protection."""
+
+    CHIMNEY_DIRTY = "E102"
+    """Chimney/burning pot dirty, or manually stopped before flame detection."""
+
+    SENSOR_T02 = "E105"
+    """Sensor T02 malfunction or disconnected."""
+
+    SENSOR_T03_T05 = "E106"
+    """Sensor T03 or T05 malfunction or disconnected."""
+
+    SENSOR_T04 = "E107"
+    """Sensor T04 malfunction or disconnected."""
+
+    SAFETY_SWITCH = "E108"
+    """Security switch I01 tripped (STB). Reset and restart."""
+
+    PRESSURE_SENSOR_OFF = "E109"
+    """Pressure sensor switched OFF. Reset and restart."""
+
+    SENSOR_T01_T02 = "E110"
+    """Sensor T01 or T02 malfunction or disconnected."""
+
+    SENSOR_T01_T03 = "E111"
+    """Sensor T01 or T03 malfunction or disconnected."""
+
+    FLUE_GAS_OVERTEMP = "E113"
+    """Flue gases overtemperature. Clean chimney/heat exchanger."""
+
+    FUEL_IGNITION_TIMEOUT = "E114"
+    """Fuel ignition timeout (empty burning pot) or tank empty."""
+
+    GENERAL_ERROR = "E115"
+    """General error. Call service."""
+
+    MFDOOR_ALARM = "E239"
+    """MFDoor alarm."""
+
+    FIRE_ERROR = "E240"
+    """Fire error."""
+
+    CHIMNEY_ALARM = "E241"
+    """Chimney alarm."""
+
+    GRATE_ERROR = "E243"
+    """Grate error."""
+
+    NTC2_ALARM = "E244"
+    """NTC2 alarm."""
+
+    NTC3_ALARM = "E245"
+    """NTC3 alarm."""
+
+    DOOR_ALARM = "E247"
+    """Door alarm."""
+
+    PRESSURE_ALARM = "E248"
+    """Pressure alarm."""
+
+    NTC1_ALARM = "E249"
+    """NTC1 alarm."""
+
+    TC1_ALARM = "E250"
+    """TC1 alarm."""
+
+    GAS_ALARM = "E252"
+    """Gas alarm."""
+
+    NO_PELLET_ALARM = "E253"
+    """No pellet alarm."""
+
+    UNKNOWN = "unknown"
+    """Unknown or unmapped error code from the API."""
+
+    @classmethod
+    def from_code(cls, code: int) -> StoveError | None:
+        """Convert a raw error code integer to a StoveError enum.
+
+        Returns None when there is no active error (code 0).
+        """
+        if code == 0:
+            return None
+        formatted = f"E{code:03d}"
+        try:
+            return cls(formatted)
+        except ValueError:
+            return cls.UNKNOWN
+
+    @property
+    def description(self) -> str:
+        """Return a human-readable description of this error."""
+        return _ERROR_DESCRIPTIONS.get(self, self.value)
+
+
+class StoveAlert(StrEnum):
+    """Stove alert/warning code (from controller.alert).
+
+    Values match the display format on the device (e.g., A004).
+    Use `StoveAlert.from_code()` to convert the raw integer from the API.
+    """
+
+    LOW_FUEL = "A001"
+    """Low fuel level - refuel the tank."""
+
+    SERVICE_DUE = "A002"
+    """Service due - call for regular maintenance."""
+
+    FLUE_GAS_WARNING = "A003"
+    """Flue gas temperature warning - clean chimney/heat exchanger."""
+
+    LOW_BATTERY = "A004"
+    """Low battery - call service for replacement."""
+
+    SPEED_SENSOR_FAILURE = "A005"
+    """Speed sensor failure - call service."""
+
+    DOOR_OPEN = "A006"
+    """Door open - close the door."""
+
+    AIRFLOW_MALFUNCTION = "A007"
+    """Alternative operating mode, limited functionality (airflow sensor)."""
+
+    UNKNOWN = "unknown"
+    """Unknown or unmapped alert code from the API."""
+
+    @classmethod
+    def from_code(cls, code: int) -> StoveAlert | None:
+        """Convert a raw alert code integer to a StoveAlert enum.
+
+        Returns None when there is no active alert (code 0).
+        """
+        if code == 0:
+            return None
+        formatted = f"A{code:03d}"
+        try:
+            return cls(formatted)
+        except ValueError:
+            return cls.UNKNOWN
+
+    @property
+    def description(self) -> str:
+        """Return a human-readable description of this alert."""
+        return _ALERT_DESCRIPTIONS.get(self, self.value)
+
+
+_ERROR_DESCRIPTIONS: dict[StoveError, str] = {
+    StoveError.IGNITION_FAILED: "Ignition failed / water overtemperature / backfire protection",
+    StoveError.CHIMNEY_DIRTY: "Chimney/burning pot dirty or manually stopped",
+    StoveError.SENSOR_T02: "Sensor T02 malfunction",
+    StoveError.SENSOR_T03_T05: "Sensor T03/T05 malfunction",
+    StoveError.SENSOR_T04: "Sensor T04 malfunction",
+    StoveError.SAFETY_SWITCH: "Security switch I01 tripped (STB)",
+    StoveError.PRESSURE_SENSOR_OFF: "Pressure sensor switched OFF",
+    StoveError.SENSOR_T01_T02: "Sensor T01/T02 malfunction",
+    StoveError.SENSOR_T01_T03: "Sensor T01/T03 malfunction",
+    StoveError.FLUE_GAS_OVERTEMP: "Flue gas overtemperature",
+    StoveError.FUEL_IGNITION_TIMEOUT: "Fuel ignition timeout / tank empty",
+    StoveError.GENERAL_ERROR: "General error",
+    StoveError.MFDOOR_ALARM: "MFDoor Alarm",
+    StoveError.FIRE_ERROR: "Fire Error",
+    StoveError.CHIMNEY_ALARM: "Chimney Alarm",
+    StoveError.GRATE_ERROR: "Grate Error",
+    StoveError.NTC2_ALARM: "NTC2 Alarm",
+    StoveError.NTC3_ALARM: "NTC3 Alarm",
+    StoveError.DOOR_ALARM: "Door Alarm",
+    StoveError.PRESSURE_ALARM: "Pressure Alarm",
+    StoveError.NTC1_ALARM: "NTC1 Alarm",
+    StoveError.TC1_ALARM: "TC1 Alarm",
+    StoveError.GAS_ALARM: "Gas Alarm",
+    StoveError.NO_PELLET_ALARM: "No Pellet Alarm",
+}
+
+_ALERT_DESCRIPTIONS: dict[StoveAlert, str] = {
+    StoveAlert.LOW_FUEL: "Low fuel level",
+    StoveAlert.SERVICE_DUE: "Service due",
+    StoveAlert.FLUE_GAS_WARNING: "Flue gas temperature warning",
+    StoveAlert.LOW_BATTERY: "Low battery",
+    StoveAlert.SPEED_SENSOR_FAILURE: "Speed sensor failure",
+    StoveAlert.DOOR_OPEN: "Door open",
+    StoveAlert.AIRFLOW_MALFUNCTION: "Airflow sensor malfunction (limited mode)",
+}
+
+
 @dataclass(frozen=True)
 class StoveModelInfo:
     """Known stove model information."""

--- a/src/fumis/const.py
+++ b/src/fumis/const.py
@@ -213,6 +213,8 @@ class StoveError(StrEnum):
     @property
     def description(self) -> str:
         """Return a human-readable description of this error."""
+        if self is StoveError.UNKNOWN:
+            return "Unknown error code"
         return _ERROR_DESCRIPTIONS.get(self, self.value)
 
 
@@ -264,6 +266,8 @@ class StoveAlert(StrEnum):
     @property
     def description(self) -> str:
         """Return a human-readable description of this alert."""
+        if self is StoveAlert.UNKNOWN:
+            return "Unknown alert code"
         return _ALERT_DESCRIPTIONS.get(self, self.value)
 
 

--- a/src/fumis/models.py
+++ b/src/fumis/models.py
@@ -11,7 +11,14 @@ from mashumaro.config import BaseConfig
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 from mashumaro.types import SerializationStrategy
 
-from .const import STOVE_MODELS, StoveModelInfo, StoveState, StoveStatus
+from .const import (
+    STOVE_MODELS,
+    StoveAlert,
+    StoveError,
+    StoveModelInfo,
+    StoveState,
+    StoveStatus,
+)
 
 
 class _AwesomeVersionStrategy(SerializationStrategy):
@@ -448,6 +455,24 @@ class FumisController(_BaseModel):
     def stove_status(self) -> StoveStatus:
         """Return the stove operational status as an enum."""
         return StoveStatus(self.status)
+
+    @property
+    def stove_error(self) -> StoveError | None:
+        """Return the stove error as an enum, or None if no error.
+
+        Converts the raw integer error code to a StoveError enum
+        whose value matches the device display (e.g., E102).
+        """
+        return StoveError.from_code(self.error)
+
+    @property
+    def stove_alert(self) -> StoveAlert | None:
+        """Return the stove alert as an enum, or None if no alert.
+
+        Converts the raw integer alert code to a StoveAlert enum
+        whose value matches the device display (e.g., A004).
+        """
+        return StoveAlert.from_code(self.alert)
 
     @property
     def on(self) -> bool:

--- a/tests/test_fumis.py
+++ b/tests/test_fumis.py
@@ -18,6 +18,8 @@ from fumis import (
     FumisInfo,
     FumisResponseError,
     FumisStoveOfflineError,
+    StoveAlert,
+    StoveError,
     StoveState,
     StoveStatus,
 )
@@ -690,6 +692,68 @@ def test_stove_state(status_code: int, expected_state: StoveState) -> None:
 def test_stove_state_is_str_enum() -> None:
     """Test StoveState serializes cleanly as a string."""
     assert str(StoveState.BURNING) == "burning"
+
+
+def test_stove_error_from_code() -> None:
+    """Test StoveError.from_code conversion."""
+    assert StoveError.from_code(0) is None
+    assert StoveError.from_code(102) == StoveError.CHIMNEY_DIRTY
+    assert StoveError.from_code(241) == StoveError.CHIMNEY_ALARM
+    assert StoveError.from_code(999) == StoveError.UNKNOWN
+
+
+def test_stove_error_value_matches_device() -> None:
+    """Test StoveError values match device display format."""
+    assert str(StoveError.CHIMNEY_DIRTY) == "E102"
+    assert str(StoveError.FUEL_IGNITION_TIMEOUT) == "E114"
+    assert StoveError.CHIMNEY_DIRTY.value == "E102"
+
+
+def test_stove_error_description() -> None:
+    """Test StoveError.description returns human-readable text."""
+    assert StoveError.CHIMNEY_DIRTY.description == (
+        "Chimney/burning pot dirty or manually stopped"
+    )
+    assert StoveError.UNKNOWN.description == "Unknown error code"
+
+
+def test_stove_alert_from_code() -> None:
+    """Test StoveAlert.from_code conversion."""
+    assert StoveAlert.from_code(0) is None
+    assert StoveAlert.from_code(4) == StoveAlert.LOW_BATTERY
+    assert StoveAlert.from_code(1) == StoveAlert.LOW_FUEL
+    assert StoveAlert.from_code(99) == StoveAlert.UNKNOWN
+
+
+def test_stove_alert_value_matches_device() -> None:
+    """Test StoveAlert values match device display format."""
+    assert str(StoveAlert.LOW_BATTERY) == "A004"
+    assert str(StoveAlert.DOOR_OPEN) == "A006"
+    assert StoveAlert.LOW_FUEL.value == "A001"
+
+
+def test_stove_alert_description() -> None:
+    """Test StoveAlert.description returns human-readable text."""
+    assert StoveAlert.LOW_BATTERY.description == "Low battery"
+    assert StoveAlert.UNKNOWN.description == "Unknown alert code"
+
+
+def test_controller_stove_error_property() -> None:
+    """Test FumisController.stove_error property."""
+    info = FumisInfo.from_dict({"controller": {"error": 102}})
+    assert info.controller.stove_error == StoveError.CHIMNEY_DIRTY
+
+    info_none = FumisInfo.from_dict({"controller": {"error": 0}})
+    assert info_none.controller.stove_error is None
+
+
+def test_controller_stove_alert_property() -> None:
+    """Test FumisController.stove_alert property."""
+    info = FumisInfo.from_dict({"controller": {"alert": 4}})
+    assert info.controller.stove_alert == StoveAlert.LOW_BATTERY
+
+    info_none = FumisInfo.from_dict({"controller": {"alert": 0}})
+    assert info_none.controller.stove_alert is None
 
 
 def test_eco_mode_enabled() -> None:


### PR DESCRIPTION
## Summary

- Add `StoveError` and `StoveAlert` StrEnum classes with values matching the device display format (e.g., `StoveAlert.LOW_FUEL = "A001"`, `StoveError.CHIMNEY_DIRTY = "E102"`)
- Each enum has `from_code(int)` for API integer conversion, `.description` for human-readable text, and returns `None` for code 0 (no error/alert)
- Add `stove_error` / `stove_alert` properties on `FumisController` (same pattern as `stove_status`)
- Remove `ERROR_DESCRIPTIONS` / `ALERT_DESCRIPTIONS` dicts from CLI, replaced by enum usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)